### PR TITLE
docs(guide): rewrite Method B with natural-language Agent prompts, no shell commands

### DIFF
--- a/guide/index.md
+++ b/guide/index.md
@@ -123,14 +123,16 @@ bl --version
 
 ### 方式 B：在主流 AI Agent 框架中使用
 
-无需额外配置——只要 Agent 能执行 shell，就能调用 `bl`。
+只要 Agent 装了 `bailian-cli`（按「方式 A」一句话装好），就能在对话里**直接说人话**调用百炼能力——无需关心底层命令。
 
-| 框架 | 调用方式 |
-|------|----------|
-| Cursor | 终端 / Composer 调用 `bl ...` 命令 |
-| Qwen Code | 作为结构化工具调用，参考 [showcase](/showcase/) |
-| Claude Desktop / Claude Code | 直接 shell 调用即可（在 `claude_desktop_config.json` 里把 `command` 设为 `bl`）。若要让 Agent 调用百炼平台托管的 MCP 服务（如官方天气、日历等），用 `bl mcp list` / `bl mcp call` |
-| Windsurf / Cline / Trae | 同上，支持任意能跑 shell 的 Agent |
+| 框架 | 在它里面怎么用（直接对话） |
+|------|---------|
+| **Cursor** | 在 Composer 里说：「**帮我用百炼生成一张赛博朋克风格的猫**」。Cursor 会自动调度百炼并把生成的图片路径贴回对话 |
+| **Qwen Code** | 直接对它提需求，Qwen Code 会把任务派给百炼完成。完整示例见 [Showcase](/showcase/) |
+| **Claude Desktop / Claude Code** | 对 Claude 说：「**用百炼帮我做一段 30 秒的产品介绍视频，卖点是 XXX**」。Claude 会自主跑通整条链路 |
+| **Windsurf / Cline / Trae** | 同样——在对话框里说需求，Agent 自主完成；不需要你打任何命令 |
+
+> 💡 **想接入百炼托管的官方 MCP 服务**（如官方天气、日历、知识库等）？查看 [`/cli/` 的「MCP 集成」一节](/cli/#核心能力)，里面有专门的接入指引。
 
 ### 方式 C：使用 OpenWork（开源桌面 Agent）
 


### PR DESCRIPTION
## Summary

把 `/guide/` 第二步「方式 B：在主流 AI Agent 框架中使用」表格里残留的命令符全部清掉，改成「**用户在 Agent 对话框输入什么 → Agent 替你做什么**」的纯自然语言示例，与本教程其他章节「不打命令，对 Agent 说人话」的主线对齐。

## Before / After

**Before**（命令符堆砌）：

```
| 框架 | 调用方式 |
| Cursor | 终端 / Composer 调用 `bl ...` 命令 |
| Claude Desktop | 直接 shell 调用即可（在 `claude_desktop_config.json` 里把 `command` 设为 `bl`）。
                   若要让 Agent 调用百炼平台托管的 MCP 服务，用 `bl mcp list` / `bl mcp call` |
| ...
```

**After**（自然语言对话）：

```
| 框架 | 在它里面怎么用（直接对话） |
| Cursor | 在 Composer 里说：「帮我用百炼生成一张赛博朋克风格的猫」。
           Cursor 会自动调度百炼并把生成的图片路径贴回对话 |
| Claude Desktop | 对 Claude 说：「用百炼帮我做一段 30 秒的产品介绍视频，卖点是 XXX」。
                  Claude 会自主跑通整条链路 |
| ...
```

## 关键变更

- 表头：`调用方式` → `在它里面怎么用（直接对话）`
- 每行从「调用方法 + 命令符」改为「**用户对 Agent 说什么 + Agent 替你做什么**」的对话示例
- 删除所有命令符：`bl ...` / `claude_desktop_config.json` / `bl mcp list` / `bl mcp call`
- MCP 进阶接入提示移到表格下方 callout，指向 [`/cli/` 的「MCP 集成」一节](/cli/#核心能力)，符合「同一信息只出现一次」原则
- 首句加前提说明（「按方式 A 一句话装好」），让方式 B 自然衔接方式 A 而非孤立成命令清单

## 影响范围

仅 `guide/index.md` 一个文件，单 hunk 替换。其他章节（顶部速记 / Step 5 提示框 / Step 6 demo）的「不打命令」主线本来就是一致的，本 PR 把方式 B 这处遗漏补齐。

## 验证

- [ ] `/guide/` Step 2 方式 B 表格无任何反引号包裹的命令符
- [ ] 4 行示例都以「在 X 里说……」或「对 X 说……」开头
- [ ] 表格下方 MCP callout 链接点击后正确跳转 `/cli/#核心能力`
- [ ] Step 2 方式 A / 方式 C 不受影响

---

🤖 Generated with [Qoder](https://qoder.com)
