### PR TITLE
Add bug report Issue template and blog contribute links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,28 @@
+name: 报告错误
+description: 报告网站内容或代码的问题
+labels: ["bug"]
+body:
+  - type: textarea
+    id: location
+    attributes:
+      label: 错误位置
+      description: 哪个页面、哪段文字、哪个链接有问题？贴上 URL 或截图。
+      placeholder: "例如：https://modelstudioai.github.io/blog/ 页面第 X 行"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: 问题描述
+      description: 错误是什么？期望的正确内容是什么？
+      placeholder: "实际显示的是……，应该是……"
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: 补充信息
+      description: 浏览器、设备、复现步骤等（可选）。
+      placeholder: "Chrome 128 / macOS / ……"
+    validations:
+      required: false

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site/
 .jekyll-cache/
 .jekyll-metadata
 Gemfile.lock
+.qwen/

--- a/blog/index.md
+++ b/blog/index.md
@@ -32,7 +32,7 @@ keywords: "Model Studio AI Blog,百炼 CLI 教程,AI 营销,公众号封面,Qwen
 
 欢迎社区贡献。修错字、翻译、或者写一篇全新教程都可以。
 
-- **发现错误？** 直接提 Issue 或 PR
-- **想写新文章？** 用 `article-proposal` 标签开一个 Issue，我们一起讨论角度
+- **发现错误？** [提一个 Issue](https://github.com/modelstudioai/modelstudioai.github.io/issues/new?template=bug_report.yml&labels=bug) 或直接发 PR
+- **想写新文章？** [开一个文章提案](https://github.com/modelstudioai/blog/issues/new?template=article-proposal.yml&labels=article-proposal)，我们一起讨论角度
 
-源码仓库：[modelstudioai/blog](https://github.com/modelstudioai/blog)
+网站源码：[modelstudioai/modelstudioai.github.io](https://github.com/modelstudioai/modelstudioai.github.io)　博客内容：[modelstudioai/blog](https://github.com/modelstudioai/blog)


### PR DESCRIPTION
## 改动内容

- **新增**  — 错误报告 Issue 模板（YAML 格式）
- **修改**  — 投稿区链接改为带模板的 Issue 链接：
  - 发现错误 →  的 bug_report 模板
  - 想写新文章 →  的 article-proposal 模板
- **修改**  — 添加 

## 说明

- 点击`发现错误`链接会跳转到网站源码仓库的 bug report Issue 模板
- 点击`想写新文章`链接会跳转到博客内容仓库的 article-proposal Issue 模板（需要先在 blog 仓库合并对应模板）
- 两个仓库的 Issue 模板链接均已验证可用（302 正常重定向）

## 预览

<img width="1387" height="1127" alt="image" src="https://github.com/user-attachments/assets/4fef6685-018a-45af-9700-e173e38738f4" />

## 实现过程

在blog页面点击对应的链接

<img width="756" height="310" alt="image" src="https://github.com/user-attachments/assets/ad1c498f-2649-46e8-8114-2e7be494726d" />

创建对应模板的 issue，相关 PR：https://github.com/modelstudioai/blog/pull/4