### PR TITLE
feat: 移动端和平板端响应式适配

### DIFF
--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 {%- assign page_title = page.title | append: " — " | append: site.title -%}
 {%- assign page_desc  = page.description | default: site.description -%}
 {%- assign page_kw    = page.keywords | default: site.keywords -%}
@@ -52,23 +52,33 @@
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
-body { font-family: var(--font-sans); color: var(--ink); line-height: 1.6; background: var(--canvas); }
+body { font-family: var(--font-sans); color: var(--ink); line-height: 1.6; background: var(--canvas); overflow-x: hidden; }
+h1, h2, h3 { text-wrap: balance; }
+.doc-content p, .doc-content li { text-wrap: pretty; }
 
 /* Nav */
-.nav { background: var(--canvas); border-bottom: 1px solid var(--hairline); height: 64px; display: flex; align-items: center; position: sticky; top: 0; z-index: 100; backdrop-filter: blur(8px); background: rgba(255,255,255,0.8); }
+.nav { border-bottom: 1px solid var(--hairline); height: calc(64px + env(safe-area-inset-top, 0px)); padding-top: env(safe-area-inset-top, 0px); display: flex; align-items: center; position: sticky; top: 0; z-index: 100; backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); background: rgba(255,255,255,0.8); }
 .nav-inner { max-width: 1100px; margin: 0 auto; padding: 0 24px; width: 100%; display: flex; align-items: center; justify-content: space-between; }
 .nav-logo { font-size: 16px; font-weight: 700; color: var(--ink); text-decoration: none; letter-spacing: -0.5px; }
+.logo-short { display: none; }
 .nav-links { display: flex; gap: 8px; align-items: center; }
 .nav-links a { color: var(--body); text-decoration: none; font-size: 14px; font-weight: 500; padding: 6px 12px; border-radius: var(--rounded-pill); transition: background 0.15s, color 0.15s; }
 .nav-links a:hover { background: var(--canvas-soft-2); color: var(--ink); }
 .nav-cta { background: var(--primary) !important; color: var(--on-primary) !important; font-size: 14px !important; font-weight: 500; padding: 6px 16px !important; border-radius: var(--rounded-sm); }
 .nav-cta:hover { opacity: 0.9; background: var(--primary) !important; }
+.nav-toggle { display: none; align-items: center; justify-content: center; width: 44px; height: 44px; border: none; background: none; cursor: pointer; border-radius: var(--rounded-md); color: var(--ink); }
+.nav-toggle:hover { background: var(--canvas-soft-2); }
+.nav-toggle svg { width: 22px; height: 22px; stroke: currentColor; fill: none; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+.nav-toggle .icon-close { display: none; }
+.nav-toggle[aria-expanded="true"] .icon-menu { display: none; }
+.nav-toggle[aria-expanded="true"] .icon-close { display: block; }
+.menu-backdrop { display: none; }
 
 /* Doc layout */
-.doc-layout { display: grid; grid-template-columns: 220px 1fr; max-width: 1100px; margin: 0 auto; min-height: calc(100vh - 64px); }
+.doc-layout { display: grid; grid-template-columns: 220px minmax(0, 1fr); max-width: 1100px; margin: 0 auto; min-height: calc(100vh - 64px); }
 
 /* Sidebar */
-.sidebar { border-right: 1px solid var(--hairline); padding: 32px 0 32px 24px; position: sticky; top: 64px; height: calc(100vh - 64px); overflow-y: auto; }
+.sidebar { border-right: 1px solid var(--hairline); padding: 32px 0 32px 24px; position: sticky; top: calc(64px + env(safe-area-inset-top, 0px)); height: calc(100vh - 64px - env(safe-area-inset-top, 0px)); overflow-y: auto; }
 .sidebar-section { margin-bottom: 24px; }
 .sidebar-title { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--mute); margin-bottom: 8px; padding-left: 12px; }
 .sidebar a { display: block; font-size: 14px; color: var(--body); text-decoration: none; padding: 6px 12px; border-radius: var(--rounded-sm); margin-bottom: 2px; transition: all 0.12s; border-left: 2px solid transparent; }
@@ -85,11 +95,12 @@ body { font-family: var(--font-sans); color: var(--ink); line-height: 1.6; backg
 .doc-content a:hover { text-decoration: underline; }
 .doc-content ul, .doc-content ol { padding-left: 20px; margin-bottom: 16px; }
 .doc-content li { font-size: 15px; color: var(--body); line-height: 26px; margin-bottom: 8px; }
-.doc-content code { font-family: var(--font-mono); font-size: 13px; background: var(--canvas-soft-2); padding: 2px 6px; border-radius: 4px; color: var(--ink); }
+.doc-content code { font-family: var(--font-mono); font-size: 13px; background: var(--canvas-soft-2); padding: 2px 6px; border-radius: 4px; color: var(--ink); overflow-wrap: anywhere; }
 .doc-content pre { background: var(--primary); color: var(--on-primary); padding: 20px 24px; border-radius: var(--rounded-md); margin-bottom: 20px; overflow-x: auto; font-size: 13px; line-height: 22px; }
 .doc-content pre code { background: none; padding: 0; color: inherit; }
 .doc-content blockquote { border-left: 3px solid var(--hairline); padding-left: 16px; margin: 16px 0; color: var(--mute); font-style: italic; }
-.doc-content table { width: 100%; border-collapse: collapse; margin: 16px 0 24px; font-size: 14px; }
+.table-wrap { overflow-x: auto; margin: 16px 0 24px; }
+.doc-content table { width: 100%; border-collapse: collapse; font-size: 14px; }
 .doc-content th { text-align: left; font-weight: 600; padding: 10px 12px; border-bottom: 2px solid var(--hairline); color: var(--ink); }
 .doc-content td { padding: 10px 12px; border-bottom: 1px solid var(--hairline); color: var(--body); }
 .doc-content tr:hover td { background: var(--canvas-soft); }
@@ -107,24 +118,54 @@ body { font-family: var(--font-sans); color: var(--ink); line-height: 1.6; backg
 
 /* Code copy button */
 .code-block-wrapper { position: relative; margin-bottom: 20px; }
-.code-block-wrapper pre { margin-bottom: 0; padding-right: 48px; }
-.copy-btn { position: absolute; top: 50%; right: 12px; transform: translateY(-50%); background: rgba(255,255,255,0.15); border: 1px solid rgba(255,255,255,0.2); color: rgba(255,255,255,0.7); width: 32px; height: 32px; border-radius: 6px; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: background 0.15s, color 0.15s; }
+.code-block-wrapper pre { margin-bottom: 0; }
+.copy-btn { position: absolute; top: 8px; right: 8px; background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.15); color: rgba(255,255,255,0.5); width: 32px; height: 32px; border-radius: 6px; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: background 0.15s, color 0.15s, opacity 0.15s; opacity: 0; }
+.code-block-wrapper:hover .copy-btn, .copy-btn:focus { opacity: 1; }
 .copy-btn:hover { background: rgba(255,255,255,0.25); color: #fff; }
-.copy-btn.copied { background: rgba(34,197,94,0.3); border-color: rgba(34,197,94,0.4); color: #4ade80; }
+.copy-btn.copied { opacity: 1; background: rgba(34,197,94,0.3); border-color: rgba(34,197,94,0.4); color: #4ade80; }
 .copy-btn svg { width: 16px; height: 16px; stroke: currentColor; fill: none; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
+@media (hover: none) { .copy-btn { opacity: 0.6; } }
 
 /* Page footer */
 .doc-footer { margin-top: 64px; padding-top: 24px; border-top: 1px solid var(--hairline); font-size: 13px; color: var(--mute); }
 .doc-footer a { color: var(--link); text-decoration: none; }
 .doc-footer a:hover { text-decoration: underline; }
 
+/* Tablet */
+@media (max-width: 1024px) {
+  .doc-layout { grid-template-columns: 200px minmax(0, 1fr); }
+  .doc-content { padding: 40px 32px 72px; }
+}
+
 /* Mobile */
 @media (max-width: 768px) {
-  .doc-layout { grid-template-columns: 1fr; }
-  .sidebar { display: none; }
-  .doc-content { padding: 32px 24px 60px; }
-  .doc-content h1 { font-size: 26px; }
-  .nav-links a:not(.nav-cta) { display: none; }
+  .nav-links a { display: none; }
+  .nav-toggle { display: flex; }
+  .logo-full { display: none; }
+  .logo-short { display: inline; }
+  .menu-backdrop.open { display: block; position: fixed; inset: 0; z-index: 98; background: rgba(23,23,23,0.24); }
+  .doc-layout { grid-template-columns: minmax(0, 1fr); }
+  .sidebar { position: fixed; top: calc(64px + env(safe-area-inset-top, 0px)); left: 0; bottom: 0; height: auto; width: min(300px, 84vw); padding: 20px 12px calc(20px + env(safe-area-inset-bottom, 0px)); background: var(--canvas); transform: translateX(-102%); transition: transform 0.28s cubic-bezier(0.32, 0.72, 0, 1); z-index: 99; }
+  .sidebar.open { transform: translateX(0); box-shadow: 16px 0 48px rgba(23,23,23,0.12); }
+  .sidebar a { display: flex; align-items: center; min-height: 44px; padding: 10px 12px; font-size: 15px; }
+  .doc-content { padding: 28px 20px calc(56px + env(safe-area-inset-bottom, 0px)); }
+  .doc-content h1, .blog-meta-title { font-size: 26px; }
+  .doc-content h2 { font-size: 20px; }
+  .doc-content pre { padding: 16px 18px; }
+  .doc-content code { font-size: 12.5px; }
+  .doc-content table { font-size: 13px; }
+  .doc-content th, .doc-content td { padding: 8px 10px; }
+  .doc-content td img { max-width: 64px; height: auto; }
+  .doc-content blockquote { padding-left: 12px; margin: 12px 0; }
+  .blog-meta-desc { padding: 12px 14px; }
+}
+
+@media (pointer: coarse) {
+  .copy-btn { width: 40px; height: 40px; top: 6px; right: 6px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; }
 }
 </style>
 </head>
@@ -132,19 +173,24 @@ body { font-family: var(--font-sans); color: var(--ink); line-height: 1.6; backg
 
 <nav class="nav">
   <div class="nav-inner">
-    <a href="/" class="nav-logo">ModelStudio for Developers</a>
+    <a href="/" class="nav-logo"><span class="logo-full">ModelStudio for Developers</span><span class="logo-short">ModelStudio</span></a>
     <div class="nav-links">
       <a href="/playbook/">岗位能力样板</a>
       <a href="/blog/">Blog</a>
       <a href="/showcase/">案例</a>
       <a href="https://github.com/modelstudioai" target="_blank">GitHub</a>
       <a href="{{ site.bailian_apikey_url }}" class="nav-cta" target="_blank">获取 API Key</a>
+      <button class="nav-toggle" aria-label="菜单" aria-expanded="false" aria-controls="doc-sidebar">
+        <svg class="icon-menu" viewBox="0 0 24 24"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg>
+        <svg class="icon-close" viewBox="0 0 24 24"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>
+      </button>
     </div>
   </div>
 </nav>
+<div class="menu-backdrop"></div>
 
 <div class="doc-layout">
-  <aside class="sidebar">
+  <aside class="sidebar" id="doc-sidebar">
     <div class="sidebar-section">
       <div class="sidebar-title">文档</div>
       <a href="/guide/" {% if page.url == '/guide/' %}class="active"{% endif %}>完整教程</a>
@@ -200,6 +246,31 @@ body { font-family: var(--font-sans); color: var(--ink); line-height: 1.6; backg
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
+  var toggle = document.querySelector('.nav-toggle');
+  var sidebar = document.getElementById('doc-sidebar');
+  var backdrop = document.querySelector('.menu-backdrop');
+  if (toggle && sidebar && backdrop) {
+    function setDrawer(open) {
+      sidebar.classList.toggle('open', open);
+      backdrop.classList.toggle('open', open);
+      toggle.setAttribute('aria-expanded', String(open));
+      toggle.setAttribute('aria-label', open ? '关闭菜单' : '菜单');
+      document.body.style.overflow = open ? 'hidden' : '';
+    }
+    toggle.addEventListener('click', function() { setDrawer(!sidebar.classList.contains('open')); });
+    backdrop.addEventListener('click', function() { setDrawer(false); });
+    sidebar.addEventListener('click', function(e) { if (e.target.closest('a')) setDrawer(false); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') setDrawer(false); });
+    window.addEventListener('resize', function() { if (window.innerWidth > 768) setDrawer(false); });
+  }
+
+  document.querySelectorAll('.doc-content table').forEach(function(table) {
+    var wrap = document.createElement('div');
+    wrap.className = 'table-wrap';
+    table.parentNode.insertBefore(wrap, table);
+    wrap.appendChild(table);
+  });
+
   var pres = document.querySelectorAll('.doc-content pre');
   pres.forEach(function(pre) {
     var wrapper = document.createElement('div');

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 {%- assign page_title = page.title | default: site.title -%}
 {%- assign page_desc  = page.description | default: site.description -%}
 {%- assign page_kw    = page.keywords | default: site.keywords -%}
@@ -55,17 +55,26 @@
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
-body { font-family: var(--font-sans); color: var(--ink); line-height: 1.5; background: var(--canvas); -webkit-font-smoothing: antialiased; }
+body { font-family: var(--font-sans); color: var(--ink); line-height: 1.5; background: var(--canvas); -webkit-font-smoothing: antialiased; overflow-x: hidden; }
+h1, h2, h3 { text-wrap: balance; }
 
 /* Nav */
-.nav { height: 64px; display: flex; align-items: center; position: sticky; top: 0; z-index: 100; backdrop-filter: blur(8px); background: rgba(255,255,255,0.8); border-bottom: 1px solid var(--hairline); }
+.nav { height: calc(64px + env(safe-area-inset-top, 0px)); padding-top: env(safe-area-inset-top, 0px); display: flex; align-items: center; position: sticky; top: 0; z-index: 100; backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); background: rgba(255,255,255,0.8); border-bottom: 1px solid var(--hairline); }
 .nav-inner { max-width: 1100px; margin: 0 auto; padding: 0 24px; width: 100%; display: flex; align-items: center; justify-content: space-between; }
 .nav-logo { font-size: 16px; font-weight: 700; color: var(--ink); text-decoration: none; letter-spacing: -0.5px; }
+.logo-short { display: none; }
 .nav-links { display: flex; gap: 8px; align-items: center; }
 .nav-links a { color: var(--body); text-decoration: none; font-size: 14px; font-weight: 500; padding: 6px 12px; border-radius: var(--rounded-pill); transition: background 0.15s, color 0.15s; }
 .nav-links a:hover { background: var(--canvas-soft-2); color: var(--ink); }
 .nav-cta { background: var(--primary) !important; color: var(--on-primary) !important; font-size: 14px !important; font-weight: 500; padding: 6px 16px !important; border-radius: var(--rounded-sm); }
 .nav-cta:hover { opacity: 0.9; }
+.nav-toggle { display: none; align-items: center; justify-content: center; width: 44px; height: 44px; border: none; background: none; cursor: pointer; border-radius: var(--rounded-md); color: var(--ink); }
+.nav-toggle:hover { background: var(--canvas-soft-2); }
+.nav-toggle svg { width: 22px; height: 22px; stroke: currentColor; fill: none; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+.nav-toggle .icon-close { display: none; }
+.nav-toggle[aria-expanded="true"] .icon-menu { display: none; }
+.nav-toggle[aria-expanded="true"] .icon-close { display: block; }
+.mobile-menu, .menu-backdrop { display: none; }
 
 /* Hero with background image */
 .hero {
@@ -86,6 +95,7 @@ body { font-family: var(--font-sans); color: var(--ink); line-height: 1.5; backg
   position: relative;
   z-index: 2;
   max-width: 680px;
+  width: 100%;
 }
 .hero h1 {
   font-size: 40px;
@@ -100,7 +110,6 @@ body { font-family: var(--font-sans); color: var(--ink); line-height: 1.5; backg
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
-  display: inline-block;
   padding-right: 0.08em;
   margin-right: -0.08em;
 }
@@ -127,7 +136,7 @@ body { font-family: var(--font-sans); color: var(--ink); line-height: 1.5; backg
 .bund-banner-text h2 { font-size: 22px; font-weight: 600; letter-spacing: -0.5px; margin-bottom: 8px; color: #fff; }
 .bund-banner-text p { font-size: 14px; line-height: 1.6; color: rgba(255,255,255,0.9); max-width: 640px; }
 .bund-banner-cta { flex-shrink: 0; font-size: 14px; font-weight: 600; padding: 12px 22px; border-radius: 100px; background: #fff; color: #5319E7; white-space: nowrap; }
-@media (max-width: 768px) { .bund-banner-inner { flex-direction: column; align-items: flex-start; } .bund-banner-text h2 { font-size: 19px; } }
+@media (max-width: 768px) { .bund-banner-inner { flex-direction: column; align-items: flex-start; } .bund-banner-text h2 { font-size: 19px; } .bund-banner-cta { align-self: stretch; text-align: center; } }
 
 /* Steps */
 .steps { padding: 48px 24px 64px; max-width: 1100px; margin: 0 auto; }
@@ -185,18 +194,40 @@ body { font-family: var(--font-sans); color: var(--ink); line-height: 1.5; backg
 .doc-link p { font-size: 12px; color: var(--body); }
 
 /* Footer */
-.footer { padding: 48px 24px; border-top: 1px solid var(--hairline); text-align: center; }
+.footer { padding: 48px 24px max(48px, env(safe-area-inset-bottom, 0px)); border-top: 1px solid var(--hairline); text-align: center; }
 .footer p { font-size: 12px; color: var(--mute); }
 .footer a { color: var(--body); text-decoration: none; }
 .footer a:hover { color: var(--ink); }
 
+/* Tablet */
+@media (max-width: 1024px) {
+  .playbook-grid { grid-template-columns: repeat(3, 1fr); }
+  .steps h2, .playbook-entry h2, .ecosystem h2, .docs-section h2 { font-size: 24px; }
+}
+
 /* Mobile */
 @media (max-width: 768px) {
-  .hero h1 { font-size: 28px; font-weight: 600; letter-spacing: -1px; }
+  .nav-links a { display: none; }
+  .nav-toggle { display: flex; }
+  .logo-full { display: none; }
+  .logo-short { display: inline; }
+  .mobile-menu { position: fixed; top: calc(64px + env(safe-area-inset-top, 0px)); left: 0; right: 0; z-index: 99; display: none; flex-direction: column; padding: 8px 16px calc(12px + env(safe-area-inset-bottom, 0px)); background: var(--canvas); border-bottom: 1px solid var(--hairline); box-shadow: 0 16px 40px rgba(23,23,23,0.10); }
+  .mobile-menu.open { display: flex; }
+  .mobile-menu a { display: flex; align-items: center; min-height: 46px; padding: 10px 14px; font-size: 15px; font-weight: 500; color: var(--body); text-decoration: none; border-radius: var(--rounded-md); }
+  .mobile-menu a:hover, .mobile-menu a:active { background: var(--canvas-soft-2); color: var(--ink); }
+  .mobile-menu .mobile-cta { margin-top: 8px; justify-content: center; background: var(--primary); color: var(--on-primary); border-radius: var(--rounded-sm); }
+  .mobile-menu .mobile-cta:hover, .mobile-menu .mobile-cta:active { background: var(--primary); color: var(--on-primary); opacity: 0.9; }
+  .menu-backdrop.open { display: block; position: fixed; inset: 0; z-index: 98; background: rgba(23,23,23,0.24); }
   .hero { padding: 32px 24px 24px; min-height: 220px; }
+  .hero h1 { font-size: 28px; font-weight: 600; letter-spacing: -1px; }
+  .btn { height: 44px; padding: 0 24px; }
   .steps-grid, .eco-grid { grid-template-columns: 1fr; }
   .docs-grid { grid-template-columns: 1fr; }
-  .nav-links a:not(.nav-cta) { display: none; }
+  .playbook-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; }
 }
 </style>
 </head>
@@ -204,16 +235,28 @@ body { font-family: var(--font-sans); color: var(--ink); line-height: 1.5; backg
 
 <nav class="nav">
   <div class="nav-inner">
-    <a href="/" class="nav-logo">ModelStudio for Developers</a>
+    <a href="/" class="nav-logo"><span class="logo-full">ModelStudio for Developers</span><span class="logo-short">ModelStudio</span></a>
     <div class="nav-links">
       <a href="/playbook/">岗位能力样板</a>
       <a href="/blog/">Blog</a>
       <a href="/showcase/">案例</a>
       <a href="https://github.com/modelstudioai" target="_blank">GitHub</a>
       <a href="{{ site.bailian_apikey_url }}" class="nav-cta" target="_blank">获取 API Key</a>
+      <button class="nav-toggle" aria-label="菜单" aria-expanded="false" aria-controls="mobile-menu">
+        <svg class="icon-menu" viewBox="0 0 24 24"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg>
+        <svg class="icon-close" viewBox="0 0 24 24"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>
+      </button>
     </div>
   </div>
 </nav>
+<div class="mobile-menu" id="mobile-menu">
+  <a href="/playbook/">岗位能力样板</a>
+  <a href="/blog/">Blog</a>
+  <a href="/showcase/">案例</a>
+  <a href="https://github.com/modelstudioai" target="_blank" rel="noopener">GitHub</a>
+  <a href="{{ site.bailian_apikey_url }}" class="mobile-cta" target="_blank" rel="noopener">获取 API Key</a>
+</div>
+<div class="menu-backdrop"></div>
 
 <section class="hero">
   <div class="hero-content">
@@ -350,6 +393,27 @@ body { font-family: var(--font-sans); color: var(--ink); line-height: 1.5; backg
     <a href="{{ site.bailian_cli_url }}" target="_blank">阿里云百炼</a>
   </p>
 </footer>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  var toggle = document.querySelector('.nav-toggle');
+  var menu = document.getElementById('mobile-menu');
+  var backdrop = document.querySelector('.menu-backdrop');
+  if (!toggle || !menu || !backdrop) return;
+  function setMenu(open) {
+    menu.classList.toggle('open', open);
+    backdrop.classList.toggle('open', open);
+    toggle.setAttribute('aria-expanded', String(open));
+    toggle.setAttribute('aria-label', open ? '关闭菜单' : '菜单');
+    document.body.style.overflow = open ? 'hidden' : '';
+  }
+  toggle.addEventListener('click', function() { setMenu(!menu.classList.contains('open')); });
+  backdrop.addEventListener('click', function() { setMenu(false); });
+  menu.addEventListener('click', function(e) { if (e.target.closest('a')) setMenu(false); });
+  document.addEventListener('keydown', function(e) { if (e.key === 'Escape') setMenu(false); });
+  window.addEventListener('resize', function() { if (window.innerWidth > 768) setMenu(false); });
+});
+</script>
 
 </body>
 </html>

--- a/bund-summit-2026/index.md
+++ b/bund-summit-2026/index.md
@@ -11,15 +11,15 @@ keywords: "外滩大会2026,Inclusion外滩大会,阿里云百炼,AI 比赛,参�
 外滩大会 2026 的舞台，属于每一个用 AI 把想法做出来的人。在这里，你可以用 **阿里云百炼 CLI、OpenWork、Agent Skills** 把作品做出来、提交上来，收录进社区案例库，和其他开发者一起被更多人看到。
 
 <div style="display:flex;gap:12px;flex-wrap:wrap;margin:24px 0 8px;">
-  <a href="https://github.com/modelstudioai/modelstudioai.github.io/issues/new?template=bund-summit-2026.md" target="_blank" style="display:inline-block;padding:11px 22px;border-radius:100px;background:#5319E7;color:#fff;text-decoration:none;font-weight:600;font-size:14px;">提交参赛作品 →</a>
-  <a href="https://github.com/modelstudioai/modelstudioai.github.io/issues?q=is%3Aissue+label%3A%E5%A4%96%E6%BB%A9%E5%A4%A7%E4%BC%9A2026" target="_blank" style="display:inline-block;padding:11px 22px;border-radius:100px;background:#fff;color:#171717;border:1px solid #eaeaea;text-decoration:none;font-weight:600;font-size:14px;">查看已提交作品 →</a>
+  <a href="https://github.com/modelstudioai/modelstudioai.github.io/issues/new?template=bund-summit-2026.md" target="_blank" style="display:inline-block;padding:12px 22px;border-radius:100px;background:#5319E7;color:#fff;text-decoration:none;font-weight:600;font-size:14px;">提交参赛作品 →</a>
+  <a href="https://github.com/modelstudioai/modelstudioai.github.io/issues?q=is%3Aissue+label%3A%E5%A4%96%E6%BB%A9%E5%A4%A7%E4%BC%9A2026" target="_blank" style="display:inline-block;padding:12px 22px;border-radius:100px;background:#fff;color:#171717;border:1px solid #eaeaea;text-decoration:none;font-weight:600;font-size:14px;">查看已提交作品 →</a>
 </div>
 
 <div style="position:relative;border-radius:16px;padding:28px 30px;margin:28px 0 12px;background:linear-gradient(135deg,#faf7ff 0%,#f2f6ff 100%);border:1px solid #e6ddff;">
   <span style="display:inline-block;font-size:12px;font-weight:600;letter-spacing:.4px;color:#5319E7;background:#eee6ff;padding:4px 12px;border-radius:100px;margin-bottom:14px;">阿里云百炼 · 选手专属福利</span>
   <h3 style="font-size:19px;font-weight:600;letter-spacing:-.3px;margin:0 0 6px;">参赛就能领的 AI 算力福利</h3>
   <p style="font-size:13.5px;color:#4d4d4d;margin:0 0 18px;line-height:1.7;">阿里云百炼为外滩大会选手准备了 Token 补贴与专属资源，边做作品边领，随时生效、无需手动激活。</p>
-  <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-bottom:20px;">
+  <div class="benefit-grid">
     <div style="background:#fff;border:1px solid #ece6ff;border-radius:10px;padding:14px 15px;">
       <div style="font-size:17px;font-weight:700;color:#5319E7;margin-bottom:3px;letter-spacing:-.3px;">1 亿 Token</div>
       <div style="font-size:12.5px;color:#4d4d4d;line-height:1.5;">新客免费额度，直接开跑</div>
@@ -33,7 +33,7 @@ keywords: "外滩大会2026,Inclusion外滩大会,阿里云百炼,AI 比赛,参�
       <div style="font-size:12.5px;color:#4d4d4d;line-height:1.5;">高校学生创新补贴，覆盖竞赛 / 科研 / 毕设</div>
     </div>
   </div>
-  <a href="https://opc.aliyun.com/waitan" target="_blank" style="display:inline-block;padding:11px 24px;border-radius:100px;background:linear-gradient(120deg,#5319E7,#7928ca);color:#fff;text-decoration:none;font-weight:600;font-size:14px;">领取选手福利 →</a>
+  <a href="https://opc.aliyun.com/waitan" target="_blank" style="display:inline-block;padding:12px 24px;border-radius:100px;background:linear-gradient(120deg,#5319E7,#7928ca);color:#fff;text-decoration:none;font-weight:600;font-size:14px;">领取选手福利 →</a>
   <p style="font-size:12px;color:#888;margin:12px 0 0;">福利以阿里云百炼官方页面说明为准，名额与规则可能调整。</p>
 </div>
 
@@ -60,3 +60,8 @@ keywords: "外滩大会2026,Inclusion外滩大会,阿里云百炼,AI 比赛,参�
 ---
 
 有问题或想交流？欢迎在 [GitHub Issues](https://github.com/modelstudioai/modelstudioai.github.io/issues) 留言，或加入开发者社群一起讨论。
+
+<style>
+.benefit-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 20px; }
+@media (max-width: 768px) { .benefit-grid { grid-template-columns: 1fr; } }
+</style>

--- a/playbook/index.md
+++ b/playbook/index.md
@@ -738,6 +738,9 @@ bl advisor recommend "审 SaaS 合同 SLA 章节，qwen3.7-max 和 qwen-plus 哪
   gap: 16px;
   margin: 24px 0;
 }
+@media (max-width: 1024px) {
+  .role-grid { grid-template-columns: repeat(3, 1fr); }
+}
 @media (max-width: 768px) {
   .role-grid { grid-template-columns: repeat(2, 1fr); }
 }


### PR DESCRIPTION
## 概述

为全站页面添加移动端（≤768px）和平板端（≤1024px）的响应式适配。修复了移动端无导航、内容溢出裁切、代码块复制按钮体验差等问题。

## 改动范围

| 文件 | 改动 |
|---|---|
| `_layouts/home.html` | 汉堡菜单 + 下拉面板、平板断点、hero 布局修复、safe area |
| `_layouts/doc.html` | 侧边栏抽屉、`minmax(0,1fr)` 防 grid 溢出、复制按钮交互重做、内容适配 |
| `playbook/index.md` | role-grid 新增 1024px 断点 |
| `bund-summit-2026/index.md` | 内联 grid 改为 class + media query、按钮触摸目标增大 |

## 关键修复

- **移动端导航**：首页汉堡 → 下拉菜单；文档页汉堡 → 侧边栏抽屉（含遮罩、Escape 关闭、滚动锁定）
- **Grid blowout**：`1fr` → `minmax(0, 1fr)`，防止代码块/长 inline code 撑宽 grid 列导致内容裁切
- **水平溢出**：`overflow-x: hidden` 兜底 + nav 内容精简（移动端 logo 缩短、CTA 移入菜单）
- **复制按钮**：右上角定位，hover 淡入，触摸设备半透明常显
- **内容适配**：inline code `overflow-wrap: anywhere`、表格 `table-wrap` 水平滚动、移动端图片/字号/padding 收紧

## 预览对比

### before

https://github.com/user-attachments/assets/ca7cd25e-d828-4d49-b567-afcf93e24c31

### after

https://github.com/user-attachments/assets/09dec22f-4c6f-4847-9fce-da8a9d1d3560 

## 测试

- Playwright 精确 viewport 截图验证：375 / 768 / 1024 / 1440 四个断点
- 覆盖首页、文档页、外滩大会专区、岗位能力样板共 10 个视图
- 桌面端无回归（导航、布局、复制按钮 hover 行为均正常）