### PR TITLE
Add contributor wall page and homepage developer block

### DIFF
--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -108,6 +108,13 @@ h1, h2, h3 { text-wrap: balance; }
 .doc-content video, .doc-content iframe { max-width: 100%; height: auto; border-radius: var(--rounded-md); margin: 16px 0; display: block; }
 .doc-content hr { border: none; border-top: 1px solid var(--hairline); margin: 32px 0; }
 
+/* Contributor grid */
+.ctb-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(94px, 1fr)); gap: 20px 10px; margin: 28px 0 40px; }
+.ctb { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 4px 2px; text-decoration: none; color: var(--body); border-radius: var(--rounded-md); transition: transform 0.15s, color 0.15s; }
+.ctb:hover { transform: translateY(-2px); color: var(--ink); text-decoration: none; }
+.ctb img { width: 56px; height: 56px; border-radius: 50%; margin: 0; background: var(--canvas-soft-2); border: 1px solid var(--hairline); }
+.ctb span { font-size: 11px; line-height: 1.35; text-align: center; overflow-wrap: anywhere; }
+
 /* Code copy button */
 .code-block-wrapper { position: relative; margin-bottom: 20px; }
 .code-block-wrapper pre { margin-bottom: 0; }
@@ -192,6 +199,7 @@ h1, h2, h3 { text-wrap: balance; }
     <div class="sidebar-section">
       <div class="sidebar-title">案例</div>
       <a href="/showcase/" {% if page.url == '/showcase/' %}class="active"{% endif %}>用户案例</a>
+      <a href="/contributors/" {% if page.url == '/contributors/' %}class="active"{% endif %}>开发者墙</a>
       <a href="/workshop/" {% if page.url == '/workshop/' %}class="active"{% endif %}>Workshop</a>
     </div>
     <div class="sidebar-section">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -175,6 +175,20 @@ h1, h2, h3 { text-wrap: balance; }
 .eco-card a:hover { text-decoration: underline; }
 .eco-tag { display: inline-block; font-size: 10px; font-weight: 600; letter-spacing: 0.6px; text-transform: uppercase; color: var(--mute); background: var(--canvas-soft-2); padding: 2px 8px; border-radius: var(--rounded-pill); margin-bottom: 10px; }
 
+/* Developer wall */
+.devwall { padding: 56px 24px 64px; background: var(--canvas-soft, #fafafa); }
+.devwall-inner { max-width: 1100px; margin: 0 auto; }
+.devwall h2 { text-align: center; font-size: 28px; font-weight: 600; letter-spacing: -1px; margin: 0 0 10px; }
+.devwall .section-sub { text-align: center; font-size: 14px; color: var(--body); margin: 0 0 28px; line-height: 1.6; }
+.devwall-avatars { display: flex; flex-wrap: wrap; justify-content: center; gap: 10px; margin-bottom: 28px; }
+.devwall-avatars a { display: block; border-radius: 50%; transition: transform 0.15s; }
+.devwall-avatars a:hover { transform: translateY(-2px); }
+.devwall-avatars img { width: 48px; height: 48px; border-radius: 50%; display: block; background: var(--canvas-soft-2); border: 1px solid var(--hairline); }
+.devwall-avatars .devwall-more { display: flex; align-items: center; justify-content: center; width: 48px; height: 48px; border-radius: 50%; background: var(--primary); color: var(--on-primary); font-size: 12px; font-weight: 600; text-decoration: none; }
+.devwall-cta-wrap { text-align: center; }
+.devwall-cta { display: inline-block; padding: 10px 22px; background: var(--ink); color: #fff; border-radius: 100px; text-decoration: none; font-size: 13px; font-weight: 500; transition: opacity 0.15s; }
+.devwall-cta:hover { opacity: 0.85; }
+
 /* Docs links */
 .docs-section { padding: 56px 24px 72px; max-width: 1100px; margin: 0 auto; }
 .docs-section h2 { text-align: center; font-size: 28px; font-weight: 600; letter-spacing: -1px; margin-bottom: 32px; }
@@ -195,7 +209,7 @@ h1, h2, h3 { text-wrap: balance; }
 @media (max-width: 1024px) {
   .playbook-grid { grid-template-columns: repeat(3, 1fr); }
   .eco-grid { grid-template-columns: repeat(2, 1fr); }
-  .steps h2, .playbook-entry h2, .ecosystem h2, .docs-section h2 { font-size: 24px; }
+  .steps h2, .playbook-entry h2, .ecosystem h2, .devwall h2, .docs-section h2 { font-size: 24px; }
 }
 
 /* Mobile */
@@ -351,6 +365,41 @@ h1, h2, h3 { text-wrap: balance; }
         <a href="https://github.com/modelstudioai/awesome-happyhorse-prompts" target="_blank">HappyHorse Prompts &rarr;</a>
       </div>
     </div>
+  </div>
+</section>
+
+<section class="devwall">
+  <div class="devwall-inner">
+    <h2>96 位开发者，98 个真实案例</h2>
+    <p class="section-sub">从小学生到博士生，从独立开发者到企业工程师 &mdash;&mdash; 他们用阿里云百炼把一个具体问题，做成了能跑起来的东西。</p>
+    <div class="devwall-avatars">
+      <a href="https://github.com/wx73306-create" target="_blank" rel="noopener" title="@wx73306-create"><img src="https://github.com/wx73306-create.png?size=96" alt="@wx73306-create" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/EthanSMC" target="_blank" rel="noopener" title="@EthanSMC"><img src="https://github.com/EthanSMC.png?size=96" alt="@EthanSMC" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/maxi-max-dev" target="_blank" rel="noopener" title="@maxi-max-dev"><img src="https://github.com/maxi-max-dev.png?size=96" alt="@maxi-max-dev" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/ShaoJun-wang" target="_blank" rel="noopener" title="@ShaoJun-wang"><img src="https://github.com/ShaoJun-wang.png?size=96" alt="@ShaoJun-wang" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/yinshubinysb-dotcom" target="_blank" rel="noopener" title="@yinshubinysb-dotcom"><img src="https://github.com/yinshubinysb-dotcom.png?size=96" alt="@yinshubinysb-dotcom" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/MrsFlower" target="_blank" rel="noopener" title="@MrsFlower"><img src="https://github.com/MrsFlower.png?size=96" alt="@MrsFlower" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/msensi" target="_blank" rel="noopener" title="@msensi"><img src="https://github.com/msensi.png?size=96" alt="@msensi" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/hotcoffeeshake" target="_blank" rel="noopener" title="@hotcoffeeshake"><img src="https://github.com/hotcoffeeshake.png?size=96" alt="@hotcoffeeshake" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/Thea729-fable" target="_blank" rel="noopener" title="@Thea729-fable"><img src="https://github.com/Thea729-fable.png?size=96" alt="@Thea729-fable" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/kkz-admin" target="_blank" rel="noopener" title="@kkz-admin"><img src="https://github.com/kkz-admin.png?size=96" alt="@kkz-admin" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/wanhe-hash" target="_blank" rel="noopener" title="@wanhe-hash"><img src="https://github.com/wanhe-hash.png?size=96" alt="@wanhe-hash" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/farlyfeifei" target="_blank" rel="noopener" title="@farlyfeifei"><img src="https://github.com/farlyfeifei.png?size=96" alt="@farlyfeifei" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/tbszz" target="_blank" rel="noopener" title="@tbszz"><img src="https://github.com/tbszz.png?size=96" alt="@tbszz" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/gengcheng" target="_blank" rel="noopener" title="@gengcheng"><img src="https://github.com/gengcheng.png?size=96" alt="@gengcheng" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/GavinZhao19" target="_blank" rel="noopener" title="@GavinZhao19"><img src="https://github.com/GavinZhao19.png?size=96" alt="@GavinZhao19" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/rojalus" target="_blank" rel="noopener" title="@rojalus"><img src="https://github.com/rojalus.png?size=96" alt="@rojalus" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/CNWU16" target="_blank" rel="noopener" title="@CNWU16"><img src="https://github.com/CNWU16.png?size=96" alt="@CNWU16" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/myfx1199" target="_blank" rel="noopener" title="@myfx1199"><img src="https://github.com/myfx1199.png?size=96" alt="@myfx1199" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/bianzigege" target="_blank" rel="noopener" title="@bianzigege"><img src="https://github.com/bianzigege.png?size=96" alt="@bianzigege" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/youngys012345-ai" target="_blank" rel="noopener" title="@youngys012345-ai"><img src="https://github.com/youngys012345-ai.png?size=96" alt="@youngys012345-ai" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/Pinkie-Pie-Lucky" target="_blank" rel="noopener" title="@Pinkie-Pie-Lucky"><img src="https://github.com/Pinkie-Pie-Lucky.png?size=96" alt="@Pinkie-Pie-Lucky" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/coocoo-pineapple" target="_blank" rel="noopener" title="@coocoo-pineapple"><img src="https://github.com/coocoo-pineapple.png?size=96" alt="@coocoo-pineapple" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/Zijia369" target="_blank" rel="noopener" title="@Zijia369"><img src="https://github.com/Zijia369.png?size=96" alt="@Zijia369" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/emajjsky" target="_blank" rel="noopener" title="@emajjsky"><img src="https://github.com/emajjsky.png?size=96" alt="@emajjsky" loading="lazy" width="48" height="48"></a>
+      <a class="devwall-more" href="/contributors/" title="查看全部 96 位开发者">+72</a>
+    </div>
+    <div class="devwall-cta-wrap"><a class="devwall-cta" href="/contributors/">看全部 96 位开发者 &rarr;</a></div>
   </div>
 </section>
 

--- a/contributors/index.md
+++ b/contributors/index.md
@@ -1,0 +1,126 @@
+---
+layout: doc
+title: 开发者墙
+permalink: /contributors/
+description: "阿里云百炼开源开发者计划的 96 位贡献者——Showcase 里每一个案例背后的具体开发者。"
+keywords: "阿里云百炼开发者,百炼贡献者,开发者墙,ModelStudio 社区,Showcase 作者,阿里云百炼认证开发者"
+---
+
+# 开发者墙
+
+Showcase 里的每一个案例，背后都是一位具体的开发者。下面是全部 **96 位贡献者**，按案例收录时间倒序排列。
+
+[浏览全部案例 &rarr;](/showcase/) &nbsp;&middot;&nbsp; [提交你的案例 &rarr;](https://github.com/modelstudioai/modelstudioai.github.io/issues/new)
+
+<div class="ctb-grid">
+  <a class="ctb" href="https://github.com/wx73306-create" target="_blank" rel="noopener" title="@wx73306-create"><img src="https://github.com/wx73306-create.png?size=112" alt="@wx73306-create" loading="lazy" width="56" height="56"><span>wx73306-create</span></a>
+  <a class="ctb" href="https://github.com/EthanSMC" target="_blank" rel="noopener" title="@EthanSMC"><img src="https://github.com/EthanSMC.png?size=112" alt="@EthanSMC" loading="lazy" width="56" height="56"><span>EthanSMC</span></a>
+  <a class="ctb" href="https://github.com/maxi-max-dev" target="_blank" rel="noopener" title="@maxi-max-dev"><img src="https://github.com/maxi-max-dev.png?size=112" alt="@maxi-max-dev" loading="lazy" width="56" height="56"><span>maxi-max-dev</span></a>
+  <a class="ctb" href="https://github.com/ShaoJun-wang" target="_blank" rel="noopener" title="@ShaoJun-wang"><img src="https://github.com/ShaoJun-wang.png?size=112" alt="@ShaoJun-wang" loading="lazy" width="56" height="56"><span>ShaoJun-wang</span></a>
+  <a class="ctb" href="https://github.com/yinshubinysb-dotcom" target="_blank" rel="noopener" title="@yinshubinysb-dotcom"><img src="https://github.com/yinshubinysb-dotcom.png?size=112" alt="@yinshubinysb-dotcom" loading="lazy" width="56" height="56"><span>yinshubinysb-dotcom</span></a>
+  <a class="ctb" href="https://github.com/MrsFlower" target="_blank" rel="noopener" title="@MrsFlower"><img src="https://github.com/MrsFlower.png?size=112" alt="@MrsFlower" loading="lazy" width="56" height="56"><span>MrsFlower</span></a>
+  <a class="ctb" href="https://github.com/msensi" target="_blank" rel="noopener" title="@msensi"><img src="https://github.com/msensi.png?size=112" alt="@msensi" loading="lazy" width="56" height="56"><span>msensi</span></a>
+  <a class="ctb" href="https://github.com/hotcoffeeshake" target="_blank" rel="noopener" title="@hotcoffeeshake"><img src="https://github.com/hotcoffeeshake.png?size=112" alt="@hotcoffeeshake" loading="lazy" width="56" height="56"><span>hotcoffeeshake</span></a>
+  <a class="ctb" href="https://github.com/Thea729-fable" target="_blank" rel="noopener" title="@Thea729-fable"><img src="https://github.com/Thea729-fable.png?size=112" alt="@Thea729-fable" loading="lazy" width="56" height="56"><span>Thea729-fable</span></a>
+  <a class="ctb" href="https://github.com/kkz-admin" target="_blank" rel="noopener" title="@kkz-admin"><img src="https://github.com/kkz-admin.png?size=112" alt="@kkz-admin" loading="lazy" width="56" height="56"><span>kkz-admin</span></a>
+  <a class="ctb" href="https://github.com/wanhe-hash" target="_blank" rel="noopener" title="@wanhe-hash"><img src="https://github.com/wanhe-hash.png?size=112" alt="@wanhe-hash" loading="lazy" width="56" height="56"><span>wanhe-hash</span></a>
+  <a class="ctb" href="https://github.com/farlyfeifei" target="_blank" rel="noopener" title="@farlyfeifei"><img src="https://github.com/farlyfeifei.png?size=112" alt="@farlyfeifei" loading="lazy" width="56" height="56"><span>farlyfeifei</span></a>
+  <a class="ctb" href="https://github.com/tbszz" target="_blank" rel="noopener" title="@tbszz"><img src="https://github.com/tbszz.png?size=112" alt="@tbszz" loading="lazy" width="56" height="56"><span>tbszz</span></a>
+  <a class="ctb" href="https://github.com/gengcheng" target="_blank" rel="noopener" title="@gengcheng"><img src="https://github.com/gengcheng.png?size=112" alt="@gengcheng" loading="lazy" width="56" height="56"><span>gengcheng</span></a>
+  <a class="ctb" href="https://github.com/GavinZhao19" target="_blank" rel="noopener" title="@GavinZhao19"><img src="https://github.com/GavinZhao19.png?size=112" alt="@GavinZhao19" loading="lazy" width="56" height="56"><span>GavinZhao19</span></a>
+  <a class="ctb" href="https://github.com/rojalus" target="_blank" rel="noopener" title="@rojalus"><img src="https://github.com/rojalus.png?size=112" alt="@rojalus" loading="lazy" width="56" height="56"><span>rojalus</span></a>
+  <a class="ctb" href="https://github.com/CNWU16" target="_blank" rel="noopener" title="@CNWU16"><img src="https://github.com/CNWU16.png?size=112" alt="@CNWU16" loading="lazy" width="56" height="56"><span>CNWU16</span></a>
+  <a class="ctb" href="https://github.com/myfx1199" target="_blank" rel="noopener" title="@myfx1199"><img src="https://github.com/myfx1199.png?size=112" alt="@myfx1199" loading="lazy" width="56" height="56"><span>myfx1199</span></a>
+  <a class="ctb" href="https://github.com/bianzigege" target="_blank" rel="noopener" title="@bianzigege"><img src="https://github.com/bianzigege.png?size=112" alt="@bianzigege" loading="lazy" width="56" height="56"><span>bianzigege</span></a>
+  <a class="ctb" href="https://github.com/youngys012345-ai" target="_blank" rel="noopener" title="@youngys012345-ai"><img src="https://github.com/youngys012345-ai.png?size=112" alt="@youngys012345-ai" loading="lazy" width="56" height="56"><span>youngys012345-ai</span></a>
+  <a class="ctb" href="https://github.com/Pinkie-Pie-Lucky" target="_blank" rel="noopener" title="@Pinkie-Pie-Lucky"><img src="https://github.com/Pinkie-Pie-Lucky.png?size=112" alt="@Pinkie-Pie-Lucky" loading="lazy" width="56" height="56"><span>Pinkie-Pie-Lucky</span></a>
+  <a class="ctb" href="https://github.com/coocoo-pineapple" target="_blank" rel="noopener" title="@coocoo-pineapple"><img src="https://github.com/coocoo-pineapple.png?size=112" alt="@coocoo-pineapple" loading="lazy" width="56" height="56"><span>coocoo-pineapple</span></a>
+  <a class="ctb" href="https://github.com/Zijia369" target="_blank" rel="noopener" title="@Zijia369"><img src="https://github.com/Zijia369.png?size=112" alt="@Zijia369" loading="lazy" width="56" height="56"><span>Zijia369</span></a>
+  <a class="ctb" href="https://github.com/emajjsky" target="_blank" rel="noopener" title="@emajjsky"><img src="https://github.com/emajjsky.png?size=112" alt="@emajjsky" loading="lazy" width="56" height="56"><span>emajjsky</span></a>
+  <a class="ctb" href="https://github.com/2892480843" target="_blank" rel="noopener" title="@2892480843"><img src="https://github.com/2892480843.png?size=112" alt="@2892480843" loading="lazy" width="56" height="56"><span>2892480843</span></a>
+  <a class="ctb" href="https://github.com/Tech-ArthurX" target="_blank" rel="noopener" title="@Tech-ArthurX"><img src="https://github.com/Tech-ArthurX.png?size=112" alt="@Tech-ArthurX" loading="lazy" width="56" height="56"><span>Tech-ArthurX</span></a>
+  <a class="ctb" href="https://github.com/cpufreestyle" target="_blank" rel="noopener" title="@cpufreestyle"><img src="https://github.com/cpufreestyle.png?size=112" alt="@cpufreestyle" loading="lazy" width="56" height="56"><span>cpufreestyle</span></a>
+  <a class="ctb" href="https://github.com/inoichi1009207" target="_blank" rel="noopener" title="@inoichi1009207"><img src="https://github.com/inoichi1009207.png?size=112" alt="@inoichi1009207" loading="lazy" width="56" height="56"><span>inoichi1009207</span></a>
+  <a class="ctb" href="https://github.com/xiaomowow" target="_blank" rel="noopener" title="@xiaomowow"><img src="https://github.com/xiaomowow.png?size=112" alt="@xiaomowow" loading="lazy" width="56" height="56"><span>xiaomowow</span></a>
+  <a class="ctb" href="https://github.com/fanbinkong2001" target="_blank" rel="noopener" title="@fanbinkong2001"><img src="https://github.com/fanbinkong2001.png?size=112" alt="@fanbinkong2001" loading="lazy" width="56" height="56"><span>fanbinkong2001</span></a>
+  <a class="ctb" href="https://github.com/CH2655" target="_blank" rel="noopener" title="@CH2655"><img src="https://github.com/CH2655.png?size=112" alt="@CH2655" loading="lazy" width="56" height="56"><span>CH2655</span></a>
+  <a class="ctb" href="https://github.com/fq-small" target="_blank" rel="noopener" title="@fq-small"><img src="https://github.com/fq-small.png?size=112" alt="@fq-small" loading="lazy" width="56" height="56"><span>fq-small</span></a>
+  <a class="ctb" href="https://github.com/xiaofenggan01" target="_blank" rel="noopener" title="@xiaofenggan01"><img src="https://github.com/xiaofenggan01.png?size=112" alt="@xiaofenggan01" loading="lazy" width="56" height="56"><span>xiaofenggan01</span></a>
+  <a class="ctb" href="https://github.com/TabbyYu" target="_blank" rel="noopener" title="@TabbyYu"><img src="https://github.com/TabbyYu.png?size=112" alt="@TabbyYu" loading="lazy" width="56" height="56"><span>TabbyYu</span></a>
+  <a class="ctb" href="https://github.com/CPCer" target="_blank" rel="noopener" title="@CPCer"><img src="https://github.com/CPCer.png?size=112" alt="@CPCer" loading="lazy" width="56" height="56"><span>CPCer</span></a>
+  <a class="ctb" href="https://github.com/chenchunyun1995-art" target="_blank" rel="noopener" title="@chenchunyun1995-art"><img src="https://github.com/chenchunyun1995-art.png?size=112" alt="@chenchunyun1995-art" loading="lazy" width="56" height="56"><span>chenchunyun1995-art</span></a>
+  <a class="ctb" href="https://github.com/Chozzc" target="_blank" rel="noopener" title="@Chozzc"><img src="https://github.com/Chozzc.png?size=112" alt="@Chozzc" loading="lazy" width="56" height="56"><span>Chozzc</span></a>
+  <a class="ctb" href="https://github.com/gejiong-bot" target="_blank" rel="noopener" title="@gejiong-bot"><img src="https://github.com/gejiong-bot.png?size=112" alt="@gejiong-bot" loading="lazy" width="56" height="56"><span>gejiong-bot</span></a>
+  <a class="ctb" href="https://github.com/Chengyuann" target="_blank" rel="noopener" title="@Chengyuann"><img src="https://github.com/Chengyuann.png?size=112" alt="@Chengyuann" loading="lazy" width="56" height="56"><span>Chengyuann</span></a>
+  <a class="ctb" href="https://github.com/AQI-sunny" target="_blank" rel="noopener" title="@AQI-sunny"><img src="https://github.com/AQI-sunny.png?size=112" alt="@AQI-sunny" loading="lazy" width="56" height="56"><span>AQI-sunny</span></a>
+  <a class="ctb" href="https://github.com/Karl-XZ" target="_blank" rel="noopener" title="@Karl-XZ"><img src="https://github.com/Karl-XZ.png?size=112" alt="@Karl-XZ" loading="lazy" width="56" height="56"><span>Karl-XZ</span></a>
+  <a class="ctb" href="https://github.com/xxxye661" target="_blank" rel="noopener" title="@xxxye661"><img src="https://github.com/xxxye661.png?size=112" alt="@xxxye661" loading="lazy" width="56" height="56"><span>xxxye661</span></a>
+  <a class="ctb" href="https://github.com/yvaineyu9" target="_blank" rel="noopener" title="@yvaineyu9"><img src="https://github.com/yvaineyu9.png?size=112" alt="@yvaineyu9" loading="lazy" width="56" height="56"><span>yvaineyu9</span></a>
+  <a class="ctb" href="https://github.com/23333ironnnnn" target="_blank" rel="noopener" title="@23333ironnnnn"><img src="https://github.com/23333ironnnnn.png?size=112" alt="@23333ironnnnn" loading="lazy" width="56" height="56"><span>23333ironnnnn</span></a>
+  <a class="ctb" href="https://github.com/Stellaw23" target="_blank" rel="noopener" title="@Stellaw23"><img src="https://github.com/Stellaw23.png?size=112" alt="@Stellaw23" loading="lazy" width="56" height="56"><span>Stellaw23</span></a>
+  <a class="ctb" href="https://github.com/GaoLerong" target="_blank" rel="noopener" title="@GaoLerong"><img src="https://github.com/GaoLerong.png?size=112" alt="@GaoLerong" loading="lazy" width="56" height="56"><span>GaoLerong</span></a>
+  <a class="ctb" href="https://github.com/liqinglq666" target="_blank" rel="noopener" title="@liqinglq666"><img src="https://github.com/liqinglq666.png?size=112" alt="@liqinglq666" loading="lazy" width="56" height="56"><span>liqinglq666</span></a>
+  <a class="ctb" href="https://github.com/firecangshu" target="_blank" rel="noopener" title="@firecangshu"><img src="https://github.com/firecangshu.png?size=112" alt="@firecangshu" loading="lazy" width="56" height="56"><span>firecangshu</span></a>
+  <a class="ctb" href="https://github.com/yunxinx" target="_blank" rel="noopener" title="@yunxinx"><img src="https://github.com/yunxinx.png?size=112" alt="@yunxinx" loading="lazy" width="56" height="56"><span>yunxinx</span></a>
+  <a class="ctb" href="https://github.com/yyc-labs" target="_blank" rel="noopener" title="@yyc-labs"><img src="https://github.com/yyc-labs.png?size=112" alt="@yyc-labs" loading="lazy" width="56" height="56"><span>yyc-labs</span></a>
+  <a class="ctb" href="https://github.com/SunnyLiyuxin" target="_blank" rel="noopener" title="@SunnyLiyuxin"><img src="https://github.com/SunnyLiyuxin.png?size=112" alt="@SunnyLiyuxin" loading="lazy" width="56" height="56"><span>SunnyLiyuxin</span></a>
+  <a class="ctb" href="https://github.com/dengdengli92" target="_blank" rel="noopener" title="@dengdengli92"><img src="https://github.com/dengdengli92.png?size=112" alt="@dengdengli92" loading="lazy" width="56" height="56"><span>dengdengli92</span></a>
+  <a class="ctb" href="https://github.com/ChecheChat" target="_blank" rel="noopener" title="@ChecheChat"><img src="https://github.com/ChecheChat.png?size=112" alt="@ChecheChat" loading="lazy" width="56" height="56"><span>ChecheChat</span></a>
+  <a class="ctb" href="https://github.com/gavinz0228" target="_blank" rel="noopener" title="@gavinz0228"><img src="https://github.com/gavinz0228.png?size=112" alt="@gavinz0228" loading="lazy" width="56" height="56"><span>gavinz0228</span></a>
+  <a class="ctb" href="https://github.com/ly-tt" target="_blank" rel="noopener" title="@ly-tt"><img src="https://github.com/ly-tt.png?size=112" alt="@ly-tt" loading="lazy" width="56" height="56"><span>ly-tt</span></a>
+  <a class="ctb" href="https://github.com/eurekaneon" target="_blank" rel="noopener" title="@eurekaneon"><img src="https://github.com/eurekaneon.png?size=112" alt="@eurekaneon" loading="lazy" width="56" height="56"><span>eurekaneon</span></a>
+  <a class="ctb" href="https://github.com/RealTapeL" target="_blank" rel="noopener" title="@RealTapeL"><img src="https://github.com/RealTapeL.png?size=112" alt="@RealTapeL" loading="lazy" width="56" height="56"><span>RealTapeL</span></a>
+  <a class="ctb" href="https://github.com/Bowen-Tian-0305" target="_blank" rel="noopener" title="@Bowen-Tian-0305"><img src="https://github.com/Bowen-Tian-0305.png?size=112" alt="@Bowen-Tian-0305" loading="lazy" width="56" height="56"><span>Bowen-Tian-0305</span></a>
+  <a class="ctb" href="https://github.com/Septemc" target="_blank" rel="noopener" title="@Septemc"><img src="https://github.com/Septemc.png?size=112" alt="@Septemc" loading="lazy" width="56" height="56"><span>Septemc</span></a>
+  <a class="ctb" href="https://github.com/Natra1n" target="_blank" rel="noopener" title="@Natra1n"><img src="https://github.com/Natra1n.png?size=112" alt="@Natra1n" loading="lazy" width="56" height="56"><span>Natra1n</span></a>
+  <a class="ctb" href="https://github.com/wzczv" target="_blank" rel="noopener" title="@wzczv"><img src="https://github.com/wzczv.png?size=112" alt="@wzczv" loading="lazy" width="56" height="56"><span>wzczv</span></a>
+  <a class="ctb" href="https://github.com/fanjack510-ctrl" target="_blank" rel="noopener" title="@fanjack510-ctrl"><img src="https://github.com/fanjack510-ctrl.png?size=112" alt="@fanjack510-ctrl" loading="lazy" width="56" height="56"><span>fanjack510-ctrl</span></a>
+  <a class="ctb" href="https://github.com/SherlockHolmes006" target="_blank" rel="noopener" title="@SherlockHolmes006"><img src="https://github.com/SherlockHolmes006.png?size=112" alt="@SherlockHolmes006" loading="lazy" width="56" height="56"><span>SherlockHolmes006</span></a>
+  <a class="ctb" href="https://github.com/wholubo" target="_blank" rel="noopener" title="@wholubo"><img src="https://github.com/wholubo.png?size=112" alt="@wholubo" loading="lazy" width="56" height="56"><span>wholubo</span></a>
+  <a class="ctb" href="https://github.com/MaxxxDong" target="_blank" rel="noopener" title="@MaxxxDong"><img src="https://github.com/MaxxxDong.png?size=112" alt="@MaxxxDong" loading="lazy" width="56" height="56"><span>MaxxxDong</span></a>
+  <a class="ctb" href="https://github.com/2487238628" target="_blank" rel="noopener" title="@2487238628"><img src="https://github.com/2487238628.png?size=112" alt="@2487238628" loading="lazy" width="56" height="56"><span>2487238628</span></a>
+  <a class="ctb" href="https://github.com/freemank1224" target="_blank" rel="noopener" title="@freemank1224"><img src="https://github.com/freemank1224.png?size=112" alt="@freemank1224" loading="lazy" width="56" height="56"><span>freemank1224</span></a>
+  <a class="ctb" href="https://github.com/sl820" target="_blank" rel="noopener" title="@sl820"><img src="https://github.com/sl820.png?size=112" alt="@sl820" loading="lazy" width="56" height="56"><span>sl820</span></a>
+  <a class="ctb" href="https://github.com/Roloyty" target="_blank" rel="noopener" title="@Roloyty"><img src="https://github.com/Roloyty.png?size=112" alt="@Roloyty" loading="lazy" width="56" height="56"><span>Roloyty</span></a>
+  <a class="ctb" href="https://github.com/joeytoday" target="_blank" rel="noopener" title="@joeytoday"><img src="https://github.com/joeytoday.png?size=112" alt="@joeytoday" loading="lazy" width="56" height="56"><span>joeytoday</span></a>
+  <a class="ctb" href="https://github.com/pzb5471" target="_blank" rel="noopener" title="@pzb5471"><img src="https://github.com/pzb5471.png?size=112" alt="@pzb5471" loading="lazy" width="56" height="56"><span>pzb5471</span></a>
+  <a class="ctb" href="https://github.com/chenlikun2010" target="_blank" rel="noopener" title="@chenlikun2010"><img src="https://github.com/chenlikun2010.png?size=112" alt="@chenlikun2010" loading="lazy" width="56" height="56"><span>chenlikun2010</span></a>
+  <a class="ctb" href="https://github.com/littlebordercollie" target="_blank" rel="noopener" title="@littlebordercollie"><img src="https://github.com/littlebordercollie.png?size=112" alt="@littlebordercollie" loading="lazy" width="56" height="56"><span>littlebordercollie</span></a>
+  <a class="ctb" href="https://github.com/captainold" target="_blank" rel="noopener" title="@captainold"><img src="https://github.com/captainold.png?size=112" alt="@captainold" loading="lazy" width="56" height="56"><span>captainold</span></a>
+  <a class="ctb" href="https://github.com/UFOyyds" target="_blank" rel="noopener" title="@UFOyyds"><img src="https://github.com/UFOyyds.png?size=112" alt="@UFOyyds" loading="lazy" width="56" height="56"><span>UFOyyds</span></a>
+  <a class="ctb" href="https://github.com/xiahaishan" target="_blank" rel="noopener" title="@xiahaishan"><img src="https://github.com/xiahaishan.png?size=112" alt="@xiahaishan" loading="lazy" width="56" height="56"><span>xiahaishan</span></a>
+  <a class="ctb" href="https://github.com/summer202607" target="_blank" rel="noopener" title="@summer202607"><img src="https://github.com/summer202607.png?size=112" alt="@summer202607" loading="lazy" width="56" height="56"><span>summer202607</span></a>
+  <a class="ctb" href="https://github.com/wanghaoyu070" target="_blank" rel="noopener" title="@wanghaoyu070"><img src="https://github.com/wanghaoyu070.png?size=112" alt="@wanghaoyu070" loading="lazy" width="56" height="56"><span>wanghaoyu070</span></a>
+  <a class="ctb" href="https://github.com/solareclipse0130" target="_blank" rel="noopener" title="@solareclipse0130"><img src="https://github.com/solareclipse0130.png?size=112" alt="@solareclipse0130" loading="lazy" width="56" height="56"><span>solareclipse0130</span></a>
+  <a class="ctb" href="https://github.com/jingwenliu123456-coder" target="_blank" rel="noopener" title="@jingwenliu123456-coder"><img src="https://github.com/jingwenliu123456-coder.png?size=112" alt="@jingwenliu123456-coder" loading="lazy" width="56" height="56"><span>jingwenliu123456-coder</span></a>
+  <a class="ctb" href="https://github.com/XiaoyangBi" target="_blank" rel="noopener" title="@XiaoyangBi"><img src="https://github.com/XiaoyangBi.png?size=112" alt="@XiaoyangBi" loading="lazy" width="56" height="56"><span>XiaoyangBi</span></a>
+  <a class="ctb" href="https://github.com/Celestebz" target="_blank" rel="noopener" title="@Celestebz"><img src="https://github.com/Celestebz.png?size=112" alt="@Celestebz" loading="lazy" width="56" height="56"><span>Celestebz</span></a>
+  <a class="ctb" href="https://github.com/SevenAILab" target="_blank" rel="noopener" title="@SevenAILab"><img src="https://github.com/SevenAILab.png?size=112" alt="@SevenAILab" loading="lazy" width="56" height="56"><span>SevenAILab</span></a>
+  <a class="ctb" href="https://github.com/streetlightstartupnotes" target="_blank" rel="noopener" title="@streetlightstartupnotes"><img src="https://github.com/streetlightstartupnotes.png?size=112" alt="@streetlightstartupnotes" loading="lazy" width="56" height="56"><span>streetlightstartupnotes</span></a>
+  <a class="ctb" href="https://github.com/oil-oil" target="_blank" rel="noopener" title="@oil-oil"><img src="https://github.com/oil-oil.png?size=112" alt="@oil-oil" loading="lazy" width="56" height="56"><span>oil-oil</span></a>
+  <a class="ctb" href="https://github.com/DawnLck" target="_blank" rel="noopener" title="@DawnLck"><img src="https://github.com/DawnLck.png?size=112" alt="@DawnLck" loading="lazy" width="56" height="56"><span>DawnLck</span></a>
+  <a class="ctb" href="https://github.com/boblank" target="_blank" rel="noopener" title="@boblank"><img src="https://github.com/boblank.png?size=112" alt="@boblank" loading="lazy" width="56" height="56"><span>boblank</span></a>
+  <a class="ctb" href="https://github.com/Unicosmos" target="_blank" rel="noopener" title="@Unicosmos"><img src="https://github.com/Unicosmos.png?size=112" alt="@Unicosmos" loading="lazy" width="56" height="56"><span>Unicosmos</span></a>
+  <a class="ctb" href="https://github.com/jamiu799" target="_blank" rel="noopener" title="@jamiu799"><img src="https://github.com/jamiu799.png?size=112" alt="@jamiu799" loading="lazy" width="56" height="56"><span>jamiu799</span></a>
+  <a class="ctb" href="https://github.com/Elianyang" target="_blank" rel="noopener" title="@Elianyang"><img src="https://github.com/Elianyang.png?size=112" alt="@Elianyang" loading="lazy" width="56" height="56"><span>Elianyang</span></a>
+  <a class="ctb" href="https://github.com/zjupump" target="_blank" rel="noopener" title="@zjupump"><img src="https://github.com/zjupump.png?size=112" alt="@zjupump" loading="lazy" width="56" height="56"><span>zjupump</span></a>
+  <a class="ctb" href="https://github.com/soulroskars" target="_blank" rel="noopener" title="@soulroskars"><img src="https://github.com/soulroskars.png?size=112" alt="@soulroskars" loading="lazy" width="56" height="56"><span>soulroskars</span></a>
+  <a class="ctb" href="https://github.com/ggly" target="_blank" rel="noopener" title="@ggly"><img src="https://github.com/ggly.png?size=112" alt="@ggly" loading="lazy" width="56" height="56"><span>ggly</span></a>
+  <a class="ctb" href="https://github.com/Danheng0502" target="_blank" rel="noopener" title="@Danheng0502"><img src="https://github.com/Danheng0502.png?size=112" alt="@Danheng0502" loading="lazy" width="56" height="56"><span>Danheng0502</span></a>
+  <a class="ctb" href="https://github.com/JeffLi1993" target="_blank" rel="noopener" title="@JeffLi1993"><img src="https://github.com/JeffLi1993.png?size=112" alt="@JeffLi1993" loading="lazy" width="56" height="56"><span>JeffLi1993</span></a>
+  <a class="ctb" href="https://github.com/cyc120" target="_blank" rel="noopener" title="@cyc120"><img src="https://github.com/cyc120.png?size=112" alt="@cyc120" loading="lazy" width="56" height="56"><span>cyc120</span></a>
+</div>
+
+## 想上这面墙？
+
+三步就能加入：
+
+1. **提交案例** —— 在 [GitHub Issues](https://github.com/modelstudioai/modelstudioai.github.io/issues/new) 描述你的项目：做了什么、用了哪些阿里云百炼能力、效果展示、项目链接。
+2. **等待收录** —— 我们会在 2–3 天内审核，收录进 [Showcase](/showcase/) 页面，你的 GitHub ID 会同步出现在这面墙上。
+3. **加入社区** —— 收录后我们会在 issue 下引导你参与「阿里云百炼认证开发者」，开通案例曝光、Workshop 演讲席位、开源合作对接等权益。
+
+不限行业方向，不看学历履历。只看一件事：你有没有把一个具体问题，用阿里云百炼真正做成一个能跑起来的东西。
+
+---
+
+> 名单以 [Showcase](/showcase/) 页面收录顺序为准，包含案例合作者。如有遗漏或需更正，欢迎[提交 Issue](https://github.com/modelstudioai/modelstudioai.github.io/issues/new) 告诉我们。

--- a/showcase/index.md
+++ b/showcase/index.md
@@ -10,7 +10,7 @@ keywords: "阿里云百炼案例,AI Agent 案例,百炼CLI,OpenWork,Showcase,社
 
 来自社区成员的真实使用案例，以及可复用的 Prompt / Skill 模板。
 
-[提交你的案例 →](https://github.com/modelstudioai/modelstudioai.github.io/issues/new)
+[看全部 96 位贡献者 &rarr;](/contributors/) &nbsp;&middot;&nbsp; [提交你的案例 &rarr;](https://github.com/modelstudioai/modelstudioai.github.io/issues/new)
 
 ---
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -43,6 +43,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://modelstudioai.github.io/contributors/</loc>
+    <lastmod>2026-09-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://modelstudioai.github.io/faq/</loc>
     <lastmod>2026-06-10</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## 背景

Showcase 里每个案例都有作者，但贡献者信息散落在近 1600 行的案例列表里，社区看不到生态的整体规模。

## 改动

- 新增 `/contributors/` 开发者墙：GitHub 头像网格展示全部 **96 位贡献者**，按 Showcase 收录顺序排列，每个头像链到本人 GitHub；页尾附「想上这面墙」三步说明。
- 首页新增开发者摘要区块（`.devwall`）：24 个头像 + `+72` 徽标 + 「看全部 96 位开发者」CTA，放在生态区块与文档区块之间。
- 文档侧栏「案例」分组加入 `开发者墙` 入口；Showcase 页顶部加「看全部 96 位贡献者」链接。
- `sitemap.xml` 收录 `/contributors/`。

名单来源为 `showcase/index.md` 的作者行（93 位主作者 + 3 位案例合作者 = 96），未搬运公众号文章正文，只做名单。

## 验证

无本地 Jekyll 环境，用脚本做最小 Liquid 展开 + Markdown 转换后以 headless Chrome 渲染截图检查：

- 开发者墙桌面端（1440px）：6 列网格、头像与 ID 对齐、侧栏 `开发者墙` 入口正常。
- 开发者墙窄屏（500px）：4 列自适应、无横向溢出、汉堡菜单正常。
- 首页桌面端与窄屏：`.devwall` 区块背景、头像换行、`+72` 徽标与 CTA 渲染正常。

未在真实 Jekyll build 下验证，合并后需确认 `/contributors/` 线上可访问。