### PR TITLE
Move developer wall block right below the three-step section

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -176,7 +176,7 @@ h1, h2, h3 { text-wrap: balance; }
 .eco-tag { display: inline-block; font-size: 10px; font-weight: 600; letter-spacing: 0.6px; text-transform: uppercase; color: var(--mute); background: var(--canvas-soft-2); padding: 2px 8px; border-radius: var(--rounded-pill); margin-bottom: 10px; }
 
 /* Developer wall */
-.devwall { padding: 56px 24px 64px; background: var(--canvas-soft, #fafafa); }
+.devwall { padding: 56px 24px 64px; background: var(--canvas-soft, #fafafa); border-bottom: 1px solid var(--hairline); }
 .devwall-inner { max-width: 1100px; margin: 0 auto; }
 .devwall h2 { text-align: center; font-size: 28px; font-weight: 600; letter-spacing: -1px; margin: 0 0 10px; }
 .devwall .section-sub { text-align: center; font-size: 14px; color: var(--body); margin: 0 0 28px; line-height: 1.6; }
@@ -298,6 +298,41 @@ h1, h2, h3 { text-wrap: balance; }
   </div>
 </section>
 
+<section class="devwall">
+  <div class="devwall-inner">
+    <h2>96 位开发者，98 个真实案例</h2>
+    <p class="section-sub">从小学生到博士生，从独立开发者到企业工程师 &mdash;&mdash; 他们用阿里云百炼把一个具体问题，做成了能跑起来的东西。</p>
+    <div class="devwall-avatars">
+      <a href="https://github.com/wx73306-create" target="_blank" rel="noopener" title="@wx73306-create"><img src="https://github.com/wx73306-create.png?size=96" alt="@wx73306-create" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/EthanSMC" target="_blank" rel="noopener" title="@EthanSMC"><img src="https://github.com/EthanSMC.png?size=96" alt="@EthanSMC" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/maxi-max-dev" target="_blank" rel="noopener" title="@maxi-max-dev"><img src="https://github.com/maxi-max-dev.png?size=96" alt="@maxi-max-dev" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/ShaoJun-wang" target="_blank" rel="noopener" title="@ShaoJun-wang"><img src="https://github.com/ShaoJun-wang.png?size=96" alt="@ShaoJun-wang" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/yinshubinysb-dotcom" target="_blank" rel="noopener" title="@yinshubinysb-dotcom"><img src="https://github.com/yinshubinysb-dotcom.png?size=96" alt="@yinshubinysb-dotcom" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/MrsFlower" target="_blank" rel="noopener" title="@MrsFlower"><img src="https://github.com/MrsFlower.png?size=96" alt="@MrsFlower" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/msensi" target="_blank" rel="noopener" title="@msensi"><img src="https://github.com/msensi.png?size=96" alt="@msensi" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/hotcoffeeshake" target="_blank" rel="noopener" title="@hotcoffeeshake"><img src="https://github.com/hotcoffeeshake.png?size=96" alt="@hotcoffeeshake" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/Thea729-fable" target="_blank" rel="noopener" title="@Thea729-fable"><img src="https://github.com/Thea729-fable.png?size=96" alt="@Thea729-fable" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/kkz-admin" target="_blank" rel="noopener" title="@kkz-admin"><img src="https://github.com/kkz-admin.png?size=96" alt="@kkz-admin" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/wanhe-hash" target="_blank" rel="noopener" title="@wanhe-hash"><img src="https://github.com/wanhe-hash.png?size=96" alt="@wanhe-hash" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/farlyfeifei" target="_blank" rel="noopener" title="@farlyfeifei"><img src="https://github.com/farlyfeifei.png?size=96" alt="@farlyfeifei" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/tbszz" target="_blank" rel="noopener" title="@tbszz"><img src="https://github.com/tbszz.png?size=96" alt="@tbszz" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/gengcheng" target="_blank" rel="noopener" title="@gengcheng"><img src="https://github.com/gengcheng.png?size=96" alt="@gengcheng" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/GavinZhao19" target="_blank" rel="noopener" title="@GavinZhao19"><img src="https://github.com/GavinZhao19.png?size=96" alt="@GavinZhao19" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/rojalus" target="_blank" rel="noopener" title="@rojalus"><img src="https://github.com/rojalus.png?size=96" alt="@rojalus" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/CNWU16" target="_blank" rel="noopener" title="@CNWU16"><img src="https://github.com/CNWU16.png?size=96" alt="@CNWU16" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/myfx1199" target="_blank" rel="noopener" title="@myfx1199"><img src="https://github.com/myfx1199.png?size=96" alt="@myfx1199" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/bianzigege" target="_blank" rel="noopener" title="@bianzigege"><img src="https://github.com/bianzigege.png?size=96" alt="@bianzigege" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/youngys012345-ai" target="_blank" rel="noopener" title="@youngys012345-ai"><img src="https://github.com/youngys012345-ai.png?size=96" alt="@youngys012345-ai" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/Pinkie-Pie-Lucky" target="_blank" rel="noopener" title="@Pinkie-Pie-Lucky"><img src="https://github.com/Pinkie-Pie-Lucky.png?size=96" alt="@Pinkie-Pie-Lucky" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/coocoo-pineapple" target="_blank" rel="noopener" title="@coocoo-pineapple"><img src="https://github.com/coocoo-pineapple.png?size=96" alt="@coocoo-pineapple" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/Zijia369" target="_blank" rel="noopener" title="@Zijia369"><img src="https://github.com/Zijia369.png?size=96" alt="@Zijia369" loading="lazy" width="48" height="48"></a>
+      <a href="https://github.com/emajjsky" target="_blank" rel="noopener" title="@emajjsky"><img src="https://github.com/emajjsky.png?size=96" alt="@emajjsky" loading="lazy" width="48" height="48"></a>
+      <a class="devwall-more" href="/contributors/" title="查看全部 96 位开发者">+72</a>
+    </div>
+    <div class="devwall-cta-wrap"><a class="devwall-cta" href="/contributors/">看全部 96 位开发者 &rarr;</a></div>
+  </div>
+</section>
+
 <section class="playbook-entry">
   <div class="playbook-entry-inner">
     <a class="playbook-headline" href="/playbook/">
@@ -365,41 +400,6 @@ h1, h2, h3 { text-wrap: balance; }
         <a href="https://github.com/modelstudioai/awesome-happyhorse-prompts" target="_blank">HappyHorse Prompts &rarr;</a>
       </div>
     </div>
-  </div>
-</section>
-
-<section class="devwall">
-  <div class="devwall-inner">
-    <h2>96 位开发者，98 个真实案例</h2>
-    <p class="section-sub">从小学生到博士生，从独立开发者到企业工程师 &mdash;&mdash; 他们用阿里云百炼把一个具体问题，做成了能跑起来的东西。</p>
-    <div class="devwall-avatars">
-      <a href="https://github.com/wx73306-create" target="_blank" rel="noopener" title="@wx73306-create"><img src="https://github.com/wx73306-create.png?size=96" alt="@wx73306-create" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/EthanSMC" target="_blank" rel="noopener" title="@EthanSMC"><img src="https://github.com/EthanSMC.png?size=96" alt="@EthanSMC" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/maxi-max-dev" target="_blank" rel="noopener" title="@maxi-max-dev"><img src="https://github.com/maxi-max-dev.png?size=96" alt="@maxi-max-dev" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/ShaoJun-wang" target="_blank" rel="noopener" title="@ShaoJun-wang"><img src="https://github.com/ShaoJun-wang.png?size=96" alt="@ShaoJun-wang" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/yinshubinysb-dotcom" target="_blank" rel="noopener" title="@yinshubinysb-dotcom"><img src="https://github.com/yinshubinysb-dotcom.png?size=96" alt="@yinshubinysb-dotcom" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/MrsFlower" target="_blank" rel="noopener" title="@MrsFlower"><img src="https://github.com/MrsFlower.png?size=96" alt="@MrsFlower" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/msensi" target="_blank" rel="noopener" title="@msensi"><img src="https://github.com/msensi.png?size=96" alt="@msensi" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/hotcoffeeshake" target="_blank" rel="noopener" title="@hotcoffeeshake"><img src="https://github.com/hotcoffeeshake.png?size=96" alt="@hotcoffeeshake" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/Thea729-fable" target="_blank" rel="noopener" title="@Thea729-fable"><img src="https://github.com/Thea729-fable.png?size=96" alt="@Thea729-fable" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/kkz-admin" target="_blank" rel="noopener" title="@kkz-admin"><img src="https://github.com/kkz-admin.png?size=96" alt="@kkz-admin" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/wanhe-hash" target="_blank" rel="noopener" title="@wanhe-hash"><img src="https://github.com/wanhe-hash.png?size=96" alt="@wanhe-hash" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/farlyfeifei" target="_blank" rel="noopener" title="@farlyfeifei"><img src="https://github.com/farlyfeifei.png?size=96" alt="@farlyfeifei" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/tbszz" target="_blank" rel="noopener" title="@tbszz"><img src="https://github.com/tbszz.png?size=96" alt="@tbszz" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/gengcheng" target="_blank" rel="noopener" title="@gengcheng"><img src="https://github.com/gengcheng.png?size=96" alt="@gengcheng" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/GavinZhao19" target="_blank" rel="noopener" title="@GavinZhao19"><img src="https://github.com/GavinZhao19.png?size=96" alt="@GavinZhao19" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/rojalus" target="_blank" rel="noopener" title="@rojalus"><img src="https://github.com/rojalus.png?size=96" alt="@rojalus" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/CNWU16" target="_blank" rel="noopener" title="@CNWU16"><img src="https://github.com/CNWU16.png?size=96" alt="@CNWU16" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/myfx1199" target="_blank" rel="noopener" title="@myfx1199"><img src="https://github.com/myfx1199.png?size=96" alt="@myfx1199" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/bianzigege" target="_blank" rel="noopener" title="@bianzigege"><img src="https://github.com/bianzigege.png?size=96" alt="@bianzigege" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/youngys012345-ai" target="_blank" rel="noopener" title="@youngys012345-ai"><img src="https://github.com/youngys012345-ai.png?size=96" alt="@youngys012345-ai" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/Pinkie-Pie-Lucky" target="_blank" rel="noopener" title="@Pinkie-Pie-Lucky"><img src="https://github.com/Pinkie-Pie-Lucky.png?size=96" alt="@Pinkie-Pie-Lucky" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/coocoo-pineapple" target="_blank" rel="noopener" title="@coocoo-pineapple"><img src="https://github.com/coocoo-pineapple.png?size=96" alt="@coocoo-pineapple" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/Zijia369" target="_blank" rel="noopener" title="@Zijia369"><img src="https://github.com/Zijia369.png?size=96" alt="@Zijia369" loading="lazy" width="48" height="48"></a>
-      <a href="https://github.com/emajjsky" target="_blank" rel="noopener" title="@emajjsky"><img src="https://github.com/emajjsky.png?size=96" alt="@emajjsky" loading="lazy" width="48" height="48"></a>
-      <a class="devwall-more" href="/contributors/" title="查看全部 96 位开发者">+72</a>
-    </div>
-    <div class="devwall-cta-wrap"><a class="devwall-cta" href="/contributors/">看全部 96 位开发者 &rarr;</a></div>
   </div>
 </section>
 


### PR DESCRIPTION
## 改动

把首页「96 位开发者，98 个真实案例」区块从「生态全景」之后上移到「三步开始」正下方。

新的首页顺序：Hero → 三步开始 → **开发者墙** → 岗位能力样板 → 生态全景 → 文档与资源。

开发者墙与下方「岗位能力样板」同为浅色底（`--canvas-soft`），移动后两段会连成一片，因此给 `.devwall` 加了一条 `border-bottom: 1px solid var(--hairline)` 保持分段。

## 验证

本地脚本展开 Liquid 后以 headless Chrome 渲染 1440px 全页截图：区块顺序正确，浅色底之间的细线分隔清晰，头像换行、`+72` 徽标与 CTA 均正常。未做真实 Jekyll build。